### PR TITLE
Send stack traces to stdout with everything else

### DIFF
--- a/src/main/scala/com/qubole/sparklens/QuboleJobListener.scala
+++ b/src/main/scala/com/qubole/sparklens/QuboleJobListener.scala
@@ -17,6 +17,8 @@
 
 package com.qubole.sparklens
 
+import java.io.PrintStream
+
 import com.qubole.sparklens.analyzer._
 import com.qubole.sparklens.common.{AggregateMetrics, AppContext, ApplicationInfo}
 import com.qubole.sparklens.timespan.{ExecutorTimeSpan, HostTimeSpan, JobTimeSpan, StageTimeSpan}
@@ -162,7 +164,7 @@ class QuboleJobListener(sparkConf: SparkConf)  extends SparkListener {
       } catch {
         case e:Throwable => {
           println(s"Failed in Analyzer ${x.getClass.getSimpleName}")
-          e.printStackTrace()
+          e.printStackTrace(new PrintStream(System.out))
         }
       }
     })

--- a/src/main/scala/com/qubole/sparklens/QuboleNotebookListener.scala
+++ b/src/main/scala/com/qubole/sparklens/QuboleNotebookListener.scala
@@ -16,6 +16,8 @@
 */
 package com.qubole.sparklens
 
+import java.io.PrintStream
+
 import com.qubole.sparklens.analyzer.{AppAnalyzer, EfficiencyStatisticsAnalyzer, ExecutorWallclockAnalyzer, StageSkewAnalyzer}
 import com.qubole.sparklens.common.AppContext
 import com.qubole.sparklens.timespan.{ExecutorTimeSpan, HostTimeSpan}
@@ -135,7 +137,7 @@ class QuboleNotebookListener(sparkConf: SparkConf) extends QuboleJobListener(spa
       } catch {
         case e:Throwable => {
           println(s"Failed in Analyzer ${x.getClass.getSimpleName}")
-          e.printStackTrace()
+          e.printStackTrace(new PrintStream(System.out))
         }
       }
     })


### PR DESCRIPTION
All the output is sent to stdout, except stacktraces in the event of an error. This just ensure it all appears together so it's easier to match up when the different outputs are sent to different files.