### PR TITLE
Exclude scalatest from transitive dependency.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,10 @@ spAppendScalaVersion := true
 libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 
+excludeDependencies ++= Seq(
+  SbtExclusionRule("org.scalatest", "scalatest")
+)
+
 testOptions in Test += Tests.Argument("-oF")
 
 scalacOptions ++= Seq("-target:jvm-1.7")

--- a/build.sbt
+++ b/build.sbt
@@ -13,11 +13,8 @@ spAppendScalaVersion := true
 
 
 libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
 
-excludeDependencies ++= Seq(
-  SbtExclusionRule("org.scalatest", "scalatest")
-)
+
 
 testOptions in Test += Tests.Argument("-oF")
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,6 @@ spAppendScalaVersion := true
 
 libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided"
 
-
-
 testOptions in Test += Tests.Argument("-oF")
 
 scalacOptions ++= Seq("-target:jvm-1.7")


### PR DESCRIPTION
Scalatest was being transitively added from spark dependency. This was causing IntelliJ idea build to fail.