### PR TITLE
Decouple reporting from spark-app

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,8 @@ spAppendScalaVersion := true
 
 
 libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion.value % "provided"
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+
+libraryDependencies +=  "org.apache.hadoop" % "hadoop-client" % "2.6.5" % "provided"
 
 testOptions in Test += Tests.Argument("-oF")
 

--- a/src/main/scala/com/qubole/sparklens/QuboleJobListener.scala
+++ b/src/main/scala/com/qubole/sparklens/QuboleJobListener.scala
@@ -17,8 +17,6 @@
 
 package com.qubole.sparklens
 
-import java.io.PrintStream
-
 import com.qubole.sparklens.analyzer._
 import com.qubole.sparklens.common.{AggregateMetrics, AppContext, ApplicationInfo}
 import com.qubole.sparklens.timespan.{ExecutorTimeSpan, HostTimeSpan, JobTimeSpan, StageTimeSpan}
@@ -164,7 +162,7 @@ class QuboleJobListener(sparkConf: SparkConf)  extends SparkListener {
       } catch {
         case e:Throwable => {
           println(s"Failed in Analyzer ${x.getClass.getSimpleName}")
-          e.printStackTrace(new PrintStream(System.out))
+          e.printStackTrace()
         }
       }
     })

--- a/src/main/scala/com/qubole/sparklens/QuboleNotebookListener.scala
+++ b/src/main/scala/com/qubole/sparklens/QuboleNotebookListener.scala
@@ -16,8 +16,6 @@
 */
 package com.qubole.sparklens
 
-import java.io.PrintStream
-
 import com.qubole.sparklens.analyzer.{AppAnalyzer, EfficiencyStatisticsAnalyzer, ExecutorWallclockAnalyzer, StageSkewAnalyzer}
 import com.qubole.sparklens.common.AppContext
 import com.qubole.sparklens.timespan.{ExecutorTimeSpan, HostTimeSpan}
@@ -137,7 +135,7 @@ class QuboleNotebookListener(sparkConf: SparkConf) extends QuboleJobListener(spa
       } catch {
         case e:Throwable => {
           println(s"Failed in Analyzer ${x.getClass.getSimpleName}")
-          e.printStackTrace(new PrintStream(System.out))
+          e.printStackTrace()
         }
       }
     })

--- a/src/main/scala/com/qubole/sparklens/analyzer/AppAnalyzer.scala
+++ b/src/main/scala/com/qubole/sparklens/analyzer/AppAnalyzer.scala
@@ -21,6 +21,8 @@ import java.util.concurrent.TimeUnit
 
 import com.qubole.sparklens.common.AppContext
 
+import scala.collection.mutable.ListBuffer
+
 /*
  * Interface for creating new Analyzers
  */
@@ -69,4 +71,32 @@ trait AppAnalyzer {
       sb.append(x)
     }
   }
+}
+
+object AppAnalyzer {
+  def startAnalyzers(appContext: AppContext): Unit = {
+    val list = new ListBuffer[AppAnalyzer]
+    list += new SimpleAppAnalyzer
+    list += new HostTimelineAnalyzer
+    list += new ExecutorTimelineAnalyzer
+    list += new AppTimelineAnalyzer
+    list += new JobOverlapAnalyzer
+    list += new EfficiencyStatisticsAnalyzer
+    list += new ExecutorWallclockAnalyzer
+    list += new StageSkewAnalyzer
+
+
+    list.foreach( x => {
+      try {
+        val output = x.analyze(appContext)
+        println(output)
+      } catch {
+        case e:Throwable => {
+          println(s"Failed in Analyzer ${x.getClass.getSimpleName}")
+          e.printStackTrace()
+        }
+      }
+    })
+  }
+
 }

--- a/src/main/scala/com/qubole/sparklens/app/ReporterApp.scala
+++ b/src/main/scala/com/qubole/sparklens/app/ReporterApp.scala
@@ -2,13 +2,13 @@ package com.qubole.sparklens.app
 
 import java.net.URI
 
-import com.google.gson.{Gson, JsonObject}
 import com.qubole.sparklens.analyzer.AppAnalyzer
-import com.qubole.sparklens.app.ReporterApp.json
-import com.qubole.sparklens.common.{AppContext, ApplicationInfo}
+import com.qubole.sparklens.common.AppContext
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
-
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST.JValue
+import org.json4s.jackson.JsonMethods.parse
 
 object ReporterApp extends App {
   checkArgs()
@@ -31,7 +31,9 @@ object ReporterApp extends App {
   }
 
   def startAnalysersFromString(json: String): Unit = {
-    val map = new Gson().fromJson(json, classOf[JsonObject])
+
+    implicit val formats = DefaultFormats
+    val map = parse(json).extract[JValue]
 
     val appContext = AppContext.getContext(map)
     AppAnalyzer.startAnalyzers(appContext)

--- a/src/main/scala/com/qubole/sparklens/app/ReporterApp.scala
+++ b/src/main/scala/com/qubole/sparklens/app/ReporterApp.scala
@@ -1,0 +1,39 @@
+package com.qubole.sparklens.app
+
+import java.net.URI
+
+import com.google.gson.{Gson, JsonObject}
+import com.qubole.sparklens.analyzer.AppAnalyzer
+import com.qubole.sparklens.app.ReporterApp.json
+import com.qubole.sparklens.common.{AppContext, ApplicationInfo}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+
+object ReporterApp extends App {
+  checkArgs()
+
+  val file = args(0)
+  val fs = FileSystem.get(new URI(file), new Configuration())
+
+  val path = new Path(file)
+  val byteArray = new Array[Byte](fs.getFileStatus(path).getLen.toInt)
+  fs.open(path).readFully(byteArray)
+
+  val json = (byteArray.map(_.toChar)).mkString
+  startAnalysersFromString(json)
+
+  private def checkArgs(): Unit = {
+    args.size match {
+      case x if x < 1 => throw new IllegalArgumentException("Need to specify sparklens data file")
+      case _ => // Do nothing
+    }
+  }
+
+  def startAnalysersFromString(json: String): Unit = {
+    val map = new Gson().fromJson(json, classOf[JsonObject])
+
+    val appContext = AppContext.getContext(map)
+    AppAnalyzer.startAnalyzers(appContext)
+  }
+}

--- a/src/main/scala/com/qubole/sparklens/common/AggregateMetrics.scala
+++ b/src/main/scala/com/qubole/sparklens/common/AggregateMetrics.scala
@@ -19,7 +19,6 @@ package com.qubole.sparklens.common
 
 import java.util.Locale
 
-import com.google.gson.{Gson, JsonObject}
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.scheduler.TaskInfo
 import org.json4s.DefaultFormats
@@ -47,6 +46,14 @@ class AggregateValue {
        | "mean": ${mean},
        | "variance": ${variance}
        }""".stripMargin
+  }
+
+  def getMap(): Map[String, Any] = {
+    Map("value" -> value,
+    "min" -> min,
+    "max" -> max,
+    "mean" -> mean,
+    "variance" -> variance)
   }
 }
 
@@ -197,18 +204,13 @@ class AggregateMetrics() {
     })
   }
 
-  override def toString(): String = {
-    getJavaMap.toString
-  }
-
-  def getJavaMap():java.util.Map[String, Any] = {
-    import scala.collection.JavaConverters._
-
-    Map("count" -> count, "map" -> map.asJava).asJava
+  def getMap(): Map[String, Any] = {
+    Map("count" -> count, "map" -> map.keys.map(key => (key.toString, map.get(key).get.getMap())).toMap)
   }
 }
 
 object AggregateMetrics extends Enumeration {
+  import org.json4s._
 
   type Metric = Value
   val shuffleWriteTime,

--- a/src/main/scala/com/qubole/sparklens/common/ApplicationInfo.scala
+++ b/src/main/scala/com/qubole/sparklens/common/ApplicationInfo.scala
@@ -16,6 +16,25 @@
 */
 package com.qubole.sparklens.common
 
+import com.google.gson.{Gson, JsonObject}
+
 case class ApplicationInfo (var applicationID:String = "NA",
                             var startTime:Long = 0L,
-                            var endTime:Long = 0L)
+                            var endTime:Long = 0L) {
+  override def toString(): String = {
+    import scala.collection.JavaConverters._
+
+    Map("applicationID" -> applicationID, "startTime" -> startTime, "endTime" -> endTime).asJava
+      .toString
+  }
+}
+
+object ApplicationInfo {
+
+  def getObject(appInfo: JsonObject): ApplicationInfo = {
+    ApplicationInfo(
+      appInfo.get("applicationID").getAsString,
+      appInfo.get("startTime").getAsLong,
+      appInfo.get("endTime").getAsLong)
+  }
+}

--- a/src/main/scala/com/qubole/sparklens/common/ApplicationInfo.scala
+++ b/src/main/scala/com/qubole/sparklens/common/ApplicationInfo.scala
@@ -16,7 +16,8 @@
 */
 package com.qubole.sparklens.common
 
-import com.google.gson.{Gson, JsonObject}
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST.JValue
 
 case class ApplicationInfo (var applicationID:String = "NA",
                             var startTime:Long = 0L,
@@ -31,10 +32,12 @@ case class ApplicationInfo (var applicationID:String = "NA",
 
 object ApplicationInfo {
 
-  def getObject(appInfo: JsonObject): ApplicationInfo = {
+  def getObject(jvalue: JValue): ApplicationInfo = {
+    implicit val formats = DefaultFormats
+
     ApplicationInfo(
-      appInfo.get("applicationID").getAsString,
-      appInfo.get("startTime").getAsLong,
-      appInfo.get("endTime").getAsLong)
+      (jvalue \ "applicationID").extract[String],
+      (jvalue \ "startTime").extract[Long],
+      (jvalue \ "endTime").extract[Long])
   }
 }

--- a/src/main/scala/com/qubole/sparklens/common/ApplicationInfo.scala
+++ b/src/main/scala/com/qubole/sparklens/common/ApplicationInfo.scala
@@ -22,11 +22,10 @@ import org.json4s.JsonAST.JValue
 case class ApplicationInfo (var applicationID:String = "NA",
                             var startTime:Long = 0L,
                             var endTime:Long = 0L) {
-  override def toString(): String = {
-    import scala.collection.JavaConverters._
 
-    Map("applicationID" -> applicationID, "startTime" -> startTime, "endTime" -> endTime).asJava
-      .toString
+  def getMap(): Map[String, Any] = {
+    implicit val formats = DefaultFormats
+    Map("applicationID" -> applicationID, "startTime" -> startTime, "endTime" -> endTime)
   }
 }
 

--- a/src/main/scala/com/qubole/sparklens/package.scala
+++ b/src/main/scala/com/qubole/sparklens/package.scala
@@ -1,0 +1,22 @@
+package com.qubole
+
+import org.apache.spark.SparkConf
+
+package object sparklens {
+
+  private [qubole] def getDumpDirectory(conf: SparkConf): String = {
+    conf.get("spark.sparklens.dump.dir", "/tmp/sparklens/")
+  }
+
+  private [qubole] def asyncReportingEnabled(conf: SparkConf): Boolean = {
+    // This will dump info to `getDumpDirectory()` and not run reporting
+    conf.getBoolean("spark.sparklens.simulation.async", false)
+  }
+
+  private [qubole] def dumpDataEnabled(conf: SparkConf): Boolean = {
+    /* When asyncReporting is dis-abled, we are not dumping data right now
+     * to maintain status quo. However, this can be changed later to always dumping.
+     */
+    conf.getBoolean("spark.sparklens.dump.data", false)
+  }
+}

--- a/src/main/scala/com/qubole/sparklens/timespan/ExecutorTimeSpan.scala
+++ b/src/main/scala/com/qubole/sparklens/timespan/ExecutorTimeSpan.scala
@@ -17,8 +17,6 @@
 
 package com.qubole.sparklens.timespan
 
-import java.util
-
 import com.qubole.sparklens.common.AggregateMetrics
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.scheduler.TaskInfo
@@ -26,8 +24,6 @@ import org.json4s.DefaultFormats
 import org.json4s.JsonAST.JValue
 
 import scala.collection.mutable
-
-
 
 class ExecutorTimeSpan(val executorID: String,
                        val hostID: String,
@@ -38,10 +34,11 @@ class ExecutorTimeSpan(val executorID: String,
     executorMetrics.update(taskMetrics, taskInfo)
   }
 
-  override def getJavaMap(): util.Map[String, _ <: Any] = {
-    import scala.collection.JavaConverters._
-    (Map("executorID" -> executorID, "hostID" -> hostID, "cores" -> cores, "executorMetrics" ->
-      executorMetrics.getJavaMap()) ++ super.getStartEndTime()).asJava
+  override def getMap(): Map[String, _ <: Any] = {
+    implicit val formats = DefaultFormats
+
+    Map("executorID" -> executorID, "hostID" -> hostID, "cores" -> cores, "executorMetrics" ->
+      executorMetrics.getMap()) ++ super.getStartEndTime()
   }
 }
 

--- a/src/main/scala/com/qubole/sparklens/timespan/HostTimeSpan.scala
+++ b/src/main/scala/com/qubole/sparklens/timespan/HostTimeSpan.scala
@@ -17,9 +17,6 @@
 
 package com.qubole.sparklens.timespan
 
-import java.util
-
-import com.google.gson.JsonObject
 import com.qubole.sparklens.common.AggregateMetrics
 import org.apache.spark.executor.TaskMetrics
 import org.apache.spark.scheduler.TaskInfo
@@ -43,10 +40,9 @@ TODO: may be mark all host end time when execution is stopped
   def updateAggregateTaskMetrics (taskMetrics: TaskMetrics, taskInfo: TaskInfo): Unit = {
     hostMetrics.update(taskMetrics, taskInfo)
   }
-  override def getJavaMap(): java.util.Map[String, _ <: Any] = {
-    import scala.collection.JavaConverters._
-    (Map("hostID" -> hostID, "hostMetrics" -> hostMetrics.getJavaMap) ++ super.getStartEndTime())
-      .asJava
+  override def getMap(): Map[String, _ <: Any] = {
+    implicit val formats = DefaultFormats
+    Map("hostID" -> hostID, "hostMetrics" -> hostMetrics.getMap) ++ super.getStartEndTime()
   }
 
 }

--- a/src/main/scala/com/qubole/sparklens/timespan/StageTimeSpan.scala
+++ b/src/main/scala/com/qubole/sparklens/timespan/StageTimeSpan.scala
@@ -16,7 +16,6 @@
 */
 package com.qubole.sparklens.timespan
 
-import java.util
 
 import com.qubole.sparklens.common.AggregateMetrics
 import org.apache.spark.executor.TaskMetrics
@@ -96,18 +95,19 @@ class StageTimeSpan(val stageID: Int, numberOfTasks: Long) extends TimeSpan {
     tempTaskTimes.clear()
   }
 
-  override def getJavaMap(): util.Map[String, _ <: Any] = {
-    import scala.collection.JavaConverters._
-    (Map(
+  override def getMap(): Map[String, _ <: Any] = {
+    implicit val formats = DefaultFormats
+
+    Map(
       "stageID" -> stageID,
       "numberOfTasks" -> numberOfTasks,
-      "stageMetrics" -> stageMetrics.getJavaMap(),
+      "stageMetrics" -> stageMetrics.getMap(),
       "minTaskLaunchTime" -> minTaskLaunchTime,
       "maxTaskFinishTime" -> maxTaskFinishTime,
       "parentStageIDs" -> parentStageIDs.mkString("[", ",", "]"),
       "taskExecutionTimes" -> taskExecutionTimes.mkString("[", ",", "]"),
       "taskPeakMemoryUsage" -> taskPeakMemoryUsage.mkString("[", ",", "]")
-    ) ++ super.getStartEndTime()).asJava
+    ) ++ super.getStartEndTime()
   }
 }
 

--- a/src/main/scala/com/qubole/sparklens/timespan/TimeSpan.scala
+++ b/src/main/scala/com/qubole/sparklens/timespan/TimeSpan.scala
@@ -16,10 +16,6 @@
 */
 package com.qubole.sparklens.timespan
 
-import java.util
-
-import com.google.gson.JsonObject
-import com.qubole.sparklens.common.AggregateMetrics
 import org.json4s.DefaultFormats
 import org.json4s.JsonAST.JValue
 
@@ -46,7 +42,7 @@ trait TimeSpan  {
       None
     }
   }
-  def getJavaMap(): util.Map[String, _ <: Any]
+  def getMap(): Map[String, _ <: Any]
 
   def getStartEndTime(): Map[String, Long] = {
     Map("startTime" -> startTime, "endTime" -> endTime)

--- a/src/main/scala/com/qubole/sparklens/timespan/TimeSpan.scala
+++ b/src/main/scala/com/qubole/sparklens/timespan/TimeSpan.scala
@@ -16,6 +16,11 @@
 */
 package com.qubole.sparklens.timespan
 
+import java.util
+
+import com.google.gson.JsonObject
+import com.qubole.sparklens.common.AggregateMetrics
+
 /*
  * We will look at the application as a sequence of timeSpans
  */
@@ -38,5 +43,15 @@ trait TimeSpan  {
     } else {
       None
     }
+  }
+  def getJavaMap(): util.Map[String, _ <: Any]
+
+  def getStartEndTime(): Map[String, Long] = {
+    Map("startTime" -> startTime, "endTime" -> endTime)
+  }
+
+  def addStartEnd(json: JsonObject): Unit = {
+    this.startTime = json.get("startTime").getAsLong
+    this.endTime = json.get("endTime").getAsLong
   }
 }

--- a/src/main/scala/com/qubole/sparklens/timespan/TimeSpan.scala
+++ b/src/main/scala/com/qubole/sparklens/timespan/TimeSpan.scala
@@ -20,6 +20,8 @@ import java.util
 
 import com.google.gson.JsonObject
 import com.qubole.sparklens.common.AggregateMetrics
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST.JValue
 
 /*
  * We will look at the application as a sequence of timeSpans
@@ -50,8 +52,9 @@ trait TimeSpan  {
     Map("startTime" -> startTime, "endTime" -> endTime)
   }
 
-  def addStartEnd(json: JsonObject): Unit = {
-    this.startTime = json.get("startTime").getAsLong
-    this.endTime = json.get("endTime").getAsLong
+  def addStartEnd(json: JValue): Unit = {
+    implicit val formats = DefaultFormats
+    this.startTime = (json \ "startTime").extract[Long]
+    this.endTime = (json \ "endTime").extract[Long]
   }
 }

--- a/src/test/compatibility-files/version-1.json
+++ b/src/test/compatibility-files/version-1.json
@@ -1,0 +1,1205 @@
+{
+  "stageIDToJobID": {
+    "1": 1,
+    "0": 0
+  },
+  "appMetrics": {
+    "count": 8,
+    "map": {
+      "taskDuration": {
+        "value": 1005,
+        "min": 5,
+        "max": 264,
+        "mean": 125.625,
+        "variance": 115417.87500000001
+      },
+      "executorRuntime": {
+        "value": 132,
+        "min": 3,
+        "max": 30,
+        "mean": 16.5,
+        "variance": 1458.0
+      },
+      "resultSize": {
+        "value": 5608,
+        "min": 699,
+        "max": 703,
+        "mean": 701.0,
+        "variance": 32.0
+      },
+      "shuffleWriteRecordsWritten": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      },
+      "shuffleReadRecordsRead": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      },
+      "memoryBytesSpilled": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      },
+      "shuffleReadBytesRead": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      },
+      "outputBytesWritten": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      },
+      "peakExecutionMemory": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      },
+      "shuffleReadRemoteBlocks": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      },
+      "shuffleWriteBytesWritten": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      },
+      "jvmGCTime": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      },
+      "shuffleReadFetchWaitTime": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      },
+      "inputBytesRead": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      },
+      "diskBytesSpilled": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      },
+      "shuffleReadLocalBlocks": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      },
+      "shuffleWriteTime": {
+        "value": 0,
+        "min": 0,
+        "max": 0,
+        "mean": 0.0,
+        "variance": 0.0
+      }
+    }
+  },
+  "hostMap": {
+    "localhost": {
+      "hostID": "localhost",
+      "hostMetrics": {
+        "count": 8,
+        "map": {
+          "taskDuration": {
+            "value": 1005,
+            "min": 5,
+            "max": 264,
+            "mean": 125.625,
+            "variance": 115417.87500000001
+          },
+          "executorRuntime": {
+            "value": 132,
+            "min": 3,
+            "max": 30,
+            "mean": 16.5,
+            "variance": 1458.0
+          },
+          "resultSize": {
+            "value": 5608,
+            "min": 699,
+            "max": 703,
+            "mean": 701.0,
+            "variance": 32.0
+          },
+          "shuffleWriteRecordsWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadRecordsRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "memoryBytesSpilled": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadBytesRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "outputBytesWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "peakExecutionMemory": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadRemoteBlocks": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleWriteBytesWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "jvmGCTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadFetchWaitTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "inputBytesRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "diskBytesSpilled": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadLocalBlocks": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleWriteTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          }
+        }
+      },
+      "startTime": 1530689397165,
+      "endTime": 0
+    }
+  },
+  "appInfo": {
+    "applicationID": "local-1530689397106",
+    "startTime": 1530689396017,
+    "endTime": 1530689407138
+  },
+  "executorMap": {
+    "driver": {
+      "startTime": 1530689397165,
+      "cores": 4,
+      "executorID": "driver",
+      "endTime": 0,
+      "hostID": "localhost",
+      "executorMetrics": {
+        "count": 8,
+        "map": {
+          "taskDuration": {
+            "value": 1005,
+            "min": 5,
+            "max": 264,
+            "mean": 125.625,
+            "variance": 115417.87500000001
+          },
+          "executorRuntime": {
+            "value": 132,
+            "min": 3,
+            "max": 30,
+            "mean": 16.5,
+            "variance": 1458.0
+          },
+          "resultSize": {
+            "value": 5608,
+            "min": 699,
+            "max": 703,
+            "mean": 701.0,
+            "variance": 32.0
+          },
+          "shuffleWriteRecordsWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadRecordsRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "memoryBytesSpilled": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadBytesRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "outputBytesWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "peakExecutionMemory": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadRemoteBlocks": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleWriteBytesWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "jvmGCTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadFetchWaitTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "inputBytesRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "diskBytesSpilled": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadLocalBlocks": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleWriteTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          }
+        }
+      }
+    }
+  },
+  "stageMap": {
+    "1": {
+      "taskPeakMemoryUsage": "[0,0,0,0]",
+      "minTaskLaunchTime": 1530689404064,
+      "startTime": 1530689404064,
+      "taskExecutionTimes": "[3,3,3,3]",
+      "stageID": 1,
+      "stageMetrics": {
+        "count": 4,
+        "map": {
+          "taskDuration": {
+            "value": 23,
+            "min": 5,
+            "max": 6,
+            "mean": 5.75,
+            "variance": 0.7499999999999998
+          },
+          "executorRuntime": {
+            "value": 12,
+            "min": 3,
+            "max": 3,
+            "mean": 3.0,
+            "variance": 0.0
+          },
+          "resultSize": {
+            "value": 2804,
+            "min": 699,
+            "max": 703,
+            "mean": 701.0,
+            "variance": 16.0
+          },
+          "shuffleWriteRecordsWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadRecordsRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "memoryBytesSpilled": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadBytesRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "outputBytesWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "peakExecutionMemory": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadRemoteBlocks": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleWriteBytesWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "jvmGCTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadFetchWaitTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "inputBytesRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "diskBytesSpilled": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadLocalBlocks": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleWriteTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          }
+        }
+      },
+      "endTime": 1530689404070,
+      "numberOfTasks": 4,
+      "maxTaskFinishTime": 1530689404070,
+      "parentStageIDs": "[]"
+    },
+    "0": {
+      "taskPeakMemoryUsage": "[0,0,0,0]",
+      "minTaskLaunchTime": 1530689402820,
+      "startTime": 1530689402820,
+      "taskExecutionTimes": "[30,30,30,30]",
+      "stageID": 0,
+      "stageMetrics": {
+        "count": 4,
+        "map": {
+          "taskDuration": {
+            "value": 982,
+            "min": 239,
+            "max": 264,
+            "mean": 245.5,
+            "variance": 456.99999999999983
+          },
+          "executorRuntime": {
+            "value": 120,
+            "min": 30,
+            "max": 30,
+            "mean": 30.0,
+            "variance": 0.0
+          },
+          "resultSize": {
+            "value": 2804,
+            "min": 699,
+            "max": 703,
+            "mean": 701.0,
+            "variance": 16.0
+          },
+          "shuffleWriteRecordsWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadRecordsRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "memoryBytesSpilled": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadBytesRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "outputBytesWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "peakExecutionMemory": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadRemoteBlocks": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleWriteBytesWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "jvmGCTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadFetchWaitTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "inputBytesRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "diskBytesSpilled": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadLocalBlocks": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleWriteTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          }
+        }
+      },
+      "endTime": 1530689403087,
+      "numberOfTasks": 4,
+      "maxTaskFinishTime": 1530689403087,
+      "parentStageIDs": "[]"
+    }
+  },
+  "jobMap": {
+    "1": {
+      "startTime": 1530689404058,
+      "endTime": 1530689404071,
+      "jobID": 1,
+      "jobMetrics": {
+        "count": 4,
+        "map": {
+          "taskDuration": {
+            "value": 23,
+            "min": 5,
+            "max": 6,
+            "mean": 5.75,
+            "variance": 0.7499999999999998
+          },
+          "executorRuntime": {
+            "value": 12,
+            "min": 3,
+            "max": 3,
+            "mean": 3.0,
+            "variance": 0.0
+          },
+          "resultSize": {
+            "value": 2804,
+            "min": 699,
+            "max": 703,
+            "mean": 701.0,
+            "variance": 16.0
+          },
+          "shuffleWriteRecordsWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadRecordsRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "memoryBytesSpilled": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadBytesRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "outputBytesWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "peakExecutionMemory": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadRemoteBlocks": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleWriteBytesWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "jvmGCTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadFetchWaitTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "inputBytesRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "diskBytesSpilled": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadLocalBlocks": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleWriteTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          }
+        }
+      },
+      "stageMap": {
+        "1": {
+          "taskPeakMemoryUsage": "[0,0,0,0]",
+          "minTaskLaunchTime": 1530689404064,
+          "startTime": 1530689404064,
+          "taskExecutionTimes": "[3,3,3,3]",
+          "stageID": 1,
+          "stageMetrics": {
+            "count": 4,
+            "map": {
+              "taskDuration": {
+                "value": 23,
+                "min": 5,
+                "max": 6,
+                "mean": 5.75,
+                "variance": 0.7499999999999998
+              },
+              "executorRuntime": {
+                "value": 12,
+                "min": 3,
+                "max": 3,
+                "mean": 3.0,
+                "variance": 0.0
+              },
+              "resultSize": {
+                "value": 2804,
+                "min": 699,
+                "max": 703,
+                "mean": 701.0,
+                "variance": 16.0
+              },
+              "shuffleWriteRecordsWritten": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleReadRecordsRead": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "memoryBytesSpilled": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleReadBytesRead": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "outputBytesWritten": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "peakExecutionMemory": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleReadRemoteBlocks": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleWriteBytesWritten": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "jvmGCTime": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleReadFetchWaitTime": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "inputBytesRead": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "diskBytesSpilled": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleReadLocalBlocks": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleWriteTime": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              }
+            }
+          },
+          "endTime": 1530689404070,
+          "numberOfTasks": 4,
+          "maxTaskFinishTime": 1530689404070,
+          "parentStageIDs": "[]"
+        }
+      }
+    },
+    "0": {
+      "startTime": 1530689402577,
+      "endTime": 1530689403101,
+      "jobID": 0,
+      "jobMetrics": {
+        "count": 4,
+        "map": {
+          "taskDuration": {
+            "value": 982,
+            "min": 239,
+            "max": 264,
+            "mean": 245.5,
+            "variance": 456.99999999999983
+          },
+          "executorRuntime": {
+            "value": 120,
+            "min": 30,
+            "max": 30,
+            "mean": 30.0,
+            "variance": 0.0
+          },
+          "resultSize": {
+            "value": 2804,
+            "min": 699,
+            "max": 703,
+            "mean": 701.0,
+            "variance": 16.0
+          },
+          "shuffleWriteRecordsWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadRecordsRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "memoryBytesSpilled": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadBytesRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "outputBytesWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "peakExecutionMemory": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadRemoteBlocks": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleWriteBytesWritten": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "jvmGCTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadFetchWaitTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "inputBytesRead": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "diskBytesSpilled": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleReadLocalBlocks": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          },
+          "shuffleWriteTime": {
+            "value": 0,
+            "min": 0,
+            "max": 0,
+            "mean": 0.0,
+            "variance": 0.0
+          }
+        }
+      },
+      "stageMap": {
+        "0": {
+          "taskPeakMemoryUsage": "[0,0,0,0]",
+          "minTaskLaunchTime": 1530689402820,
+          "startTime": 1530689402820,
+          "taskExecutionTimes": "[30,30,30,30]",
+          "stageID": 0,
+          "stageMetrics": {
+            "count": 4,
+            "map": {
+              "taskDuration": {
+                "value": 982,
+                "min": 239,
+                "max": 264,
+                "mean": 245.5,
+                "variance": 456.99999999999983
+              },
+              "executorRuntime": {
+                "value": 120,
+                "min": 30,
+                "max": 30,
+                "mean": 30.0,
+                "variance": 0.0
+              },
+              "resultSize": {
+                "value": 2804,
+                "min": 699,
+                "max": 703,
+                "mean": 701.0,
+                "variance": 16.0
+              },
+              "shuffleWriteRecordsWritten": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleReadRecordsRead": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "memoryBytesSpilled": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleReadBytesRead": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "outputBytesWritten": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "peakExecutionMemory": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleReadRemoteBlocks": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleWriteBytesWritten": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "jvmGCTime": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleReadFetchWaitTime": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "inputBytesRead": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "diskBytesSpilled": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleReadLocalBlocks": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              },
+              "shuffleWriteTime": {
+                "value": 0,
+                "min": 0,
+                "max": 0,
+                "mean": 0.0,
+                "variance": 0.0
+              }
+            }
+          },
+          "endTime": 1530689403087,
+          "numberOfTasks": 4,
+          "maxTaskFinishTime": 1530689403087,
+          "parentStageIDs": "[]"
+        }
+      }
+    }
+  }
+}

--- a/src/test/compatibility-files/version-1.output
+++ b/src/test/compatibility-files/version-1.output
@@ -1,0 +1,14 @@
+Host localhost startTime 12:59:57:165 executors count 1
+At 12:59 executors added 1 & removed  0 currently available 1
+[      0                                      ||||||||||||||||||||||||||||||||||||||||   ]
+01:00:03:087      Stage 0 ended : maxTaskTime 30 taskCount 4
+ Driver WallClock Time    00m 10s   95.17%
+ Executor WallClock Time  00m 00s   4.83%
+Minimum possible time for the app based on the critical path (with infinite resources)   00m 10s
+Minimum possible time for the app with same executors, perfect parallelism and zero skew 00m 10s
+ Total cores available to the app 4
+ Executor OneCoreComputeHours used                       00h 00m        6.15%
+ OneCoreComputeHours wasted                              00h 00m        93.85%
+ OneCoreComputeHours wasted Driver               95.17%
+ Model Error       4%
+ Executor count     2  (200%) estimated time 00m 10s and estimated cluster utilization 0.16%

--- a/src/test/scala/CompatibilitySuite.scala
+++ b/src/test/scala/CompatibilitySuite.scala
@@ -1,0 +1,48 @@
+import java.io.{ByteArrayOutputStream, FileNotFoundException, PrintStream}
+
+import com.qubole.sparklens.app.ReporterApp
+import org.scalatest.FunSuite
+
+import scala.io.Source
+import scala.util.control.Breaks._
+
+class CompatibilitySuite extends FunSuite {
+
+  test("should be able to report on previously generated sparklens dumps") {
+
+    breakable {
+
+      (1 to 100).foreach(x => { //run for the versions of sparklens output saved
+        try {
+
+          val testInput = getFileContents(
+            s"${System.getProperty("user.dir")}/src/test/compatibility-files/version-${x}.json")
+
+          val testOut = new ByteArrayOutputStream()
+          Console.withOut(new PrintStream(testOut)) {
+            ReporterApp.startAnalysersFromString(testInput)
+          }
+          val testOutput = testOut.toString
+
+          val olderOutput = getFileContents(
+            s"${System.getProperty("user.dir")}/src/test/compatibility-files/version-${x}.output")
+
+          /* checking that some important lines of the actual run also appear on
+           * running in this test using the sparklens dumps */
+          olderOutput.split("\n").foreach(line => {
+            assert(testOutput.contains(line))
+          })
+        } catch {
+          case e: FileNotFoundException => break
+        }
+      })
+    }
+  }
+
+  private def getFileContents(fileName: String): String = {
+    val bufferedSource = Source.fromFile(fileName)
+    val result = bufferedSource.mkString
+    bufferedSource.close
+    result
+  }
+}


### PR DESCRIPTION
Copying from the related issue:

"""
Right now, the simulations are run in the spark-app. This may add penalty to the app runtime.

By de-coupling simulation we can also get the additional advantage of running simulations independently on any previously-run-app. This is also a goal of de-coupling.
"""