### PR TITLE
fix: fixing getMaxConcurrent method for cases when application has not ended

### DIFF
--- a/src/main/scala/com/qubole/sparklens/common/AppContext.scala
+++ b/src/main/scala/com/qubole/sparklens/common/AppContext.scala
@@ -72,7 +72,7 @@ object AppContext {
     // sort all start and end times on basis of timing
     val sorted = map.values.flatMap(timeSpan => {
       val correctedEndTime = if (timeSpan.endTime == 0) {
-        if (appContext == null) {
+        if (appContext == null || appContext.appInfo.endTime == 0) {
           System.currentTimeMillis()
         } else appContext.appInfo.endTime
       } else timeSpan.endTime


### PR DESCRIPTION
Need to add another check in getMaxConcurrent method to check if the spark application is still running.

Came across this issue while using sparklens with spark streaming applications.

This is related to Issue #25 