### PR TITLE
Correct variance computation and add storage of accumulator

### DIFF
--- a/src/main/scala/com/qubole/sparklens/common/AggregateMetrics.scala
+++ b/src/main/scala/com/qubole/sparklens/common/AggregateMetrics.scala
@@ -71,7 +71,8 @@ object AggregateValue {
     value.max = (json \ "max").extract[Long]
     value.mean = (json \ "mean").extract[Double]
     value.variance = (json \ "variance").extract[Double]
-    value.m2 = (json \ "m2").extract[Double]
+    //making it optional for backward compatibility with sparklens.json files
+    value.m2 = (json \ "m2").extractOrElse[Double](0.0)
     value
   }
 }


### PR DESCRIPTION
This fix corrects the variance computation of an AggregateMetric.
According to the [Variance update algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_Online_algorithm), we should use an accumulator to store an intermediate result of the variance computation. This accumulator was previously wrongly called `variance`. This fix changes the variable name to `m2` and corrects the value of the resulting variance.
