### PR TITLE
Functionality to generate sparklens report via email from within Sparklens

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,8 @@ libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion.value %
 
 libraryDependencies +=  "org.apache.hadoop" % "hadoop-client" % "2.6.5" % "provided"
 
+libraryDependencies += "com.mashape.unirest" % "unirest-java" % "1.4.9"
+
 testOptions in Test += Tests.Argument("-oF")
 
 scalacOptions ++= Seq("-target:jvm-1.7")

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,8 @@ libraryDependencies +=  "org.apache.hadoop" % "hadoop-client" % "2.6.5" % "provi
 
 libraryDependencies += "com.mashape.unirest" % "unirest-java" % "1.4.9"
 
+test in assembly := {}
+
 testOptions in Test += Tests.Argument("-oF")
 
 scalacOptions ++= Seq("-target:jvm-1.7")

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,9 @@ libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion.value %
 
 libraryDependencies +=  "org.apache.hadoop" % "hadoop-client" % "2.6.5" % "provided"
 
-libraryDependencies += "com.mashape.unirest" % "unirest-java" % "1.4.9"
+libraryDependencies += "org.apache.httpcomponents" % "httpclient" % "4.5.6" % "provided"
+
+libraryDependencies += "org.apache.httpcomponents" % "httpmime" % "4.5.6" % "provided"
 
 test in assembly := {}
 

--- a/src/main/scala/com/qubole/sparklens/QuboleJobListener.scala
+++ b/src/main/scala/com/qubole/sparklens/QuboleJobListener.scala
@@ -21,7 +21,7 @@ import java.net.URI
 
 import com.qubole.sparklens.analyzer._
 import com.qubole.sparklens.common.{AggregateMetrics, AppContext, ApplicationInfo}
-import com.qubole.sparklens.helper.HDFSConfigHelper
+import com.qubole.sparklens.helper.{EmailReportHelper, HDFSConfigHelper}
 import com.qubole.sparklens.timespan.{ExecutorTimeSpan, HostTimeSpan, JobTimeSpan, StageTimeSpan}
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.SparkConf
@@ -130,14 +130,27 @@ class QuboleJobListener(sparkConf: SparkConf)  extends SparkListener {
     }
   }
 
-  private[this] def dumpData(appContext: AppContext): Unit = {
+  private[this] def dumpData(appContext: AppContext): String = {
     val dumpDir = getDumpDirectory(sparkConf)
     println(s"Saving sparkLens data to ${dumpDir}")
     val fs = FileSystem.get(new URI(dumpDir), HDFSConfigHelper.getHadoopConf(Some(sparkConf)))
-    val stream = fs.create(new Path(s"${dumpDir}/${appInfo.applicationID}.sparklens.json"))
+    val filePathStr = s"${dumpDir}/${appInfo.applicationID}.sparklens.json"
+    val stream = fs.create(new Path(filePathStr))
     val jsonString = appContext.toString
     stream.writeBytes(jsonString)
     stream.close()
+    EmailReportHelper.generateReport(filePathStr, sparkConf)
+    filePathStr
+  }
+
+  private def dumpAndDelete(appContext: AppContext): Unit = {
+    var sparklensJsonPath = _
+    try {
+      sparklensJsonPath = dumpData(appContext)
+    } finally {
+      val fs = FileSystem.get(new URI(sparklensJsonPath), HDFSConfigHelper.getHadoopConf(Some(sparkConf)))
+      fs.deleteOnExit(sparklensJsonPath)
+    }
   }
 
   override def onApplicationStart(applicationStart: SparkListenerApplicationStart): Unit = {
@@ -179,11 +192,16 @@ class QuboleJobListener(sparkConf: SparkConf)  extends SparkListener {
         dumpData(appContext)
       }
       case false => {
-        if (dumpDataEnabled(sparkConf)) dumpData(appContext)
+        if (dumpDataEnabled(sparkConf)) {
+          dumpData(appContext)
+        } else {
+          dumpAndDelete(appContext)
+        }
         AppAnalyzer.startAnalyzers(appContext)
       }
     }
   }
+
   override def onExecutorAdded(executorAdded: SparkListenerExecutorAdded): Unit = {
     val executorTimeSpan = executorMap.get(executorAdded.executorId)
     if (!executorTimeSpan.isDefined) {

--- a/src/main/scala/com/qubole/sparklens/QuboleJobListener.scala
+++ b/src/main/scala/com/qubole/sparklens/QuboleJobListener.scala
@@ -144,12 +144,12 @@ class QuboleJobListener(sparkConf: SparkConf)  extends SparkListener {
   }
 
   private def dumpAndDelete(appContext: AppContext): Unit = {
-    var sparklensJsonPath = _
+    var sparklensJsonPath = ""
     try {
       sparklensJsonPath = dumpData(appContext)
     } finally {
       val fs = FileSystem.get(new URI(sparklensJsonPath), HDFSConfigHelper.getHadoopConf(Some(sparkConf)))
-      fs.deleteOnExit(sparklensJsonPath)
+      fs.deleteOnExit(new Path(sparklensJsonPath))
     }
   }
 

--- a/src/main/scala/com/qubole/sparklens/app/ReporterApp.scala
+++ b/src/main/scala/com/qubole/sparklens/app/ReporterApp.scala
@@ -7,7 +7,7 @@ import com.ning.compress.lzf.LZFInputStream
 import com.qubole.sparklens.QuboleJobListener
 import com.qubole.sparklens.analyzer.AppAnalyzer
 import com.qubole.sparklens.common.{AppContext, Json4sWrapper}
-import com.qubole.sparklens.helper.HDFSConfigHelper
+import com.qubole.sparklens.helper.{EmailReportHelper, HDFSConfigHelper}
 import net.jpountz.lz4.LZ4BlockInputStream
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.SparkConf
@@ -21,6 +21,8 @@ object ReporterApp extends App {
   val usage = "Need to specify sparklens data file\n" +
     "Of specify event-history file and also add \"source=history\" or \"source=sparklens\".\n" +
     "If \"source\" is not specified, sparklens is chosen by default."
+
+  val conf = new SparkConf()
 
   checkArgs()
   parseInput()
@@ -69,6 +71,7 @@ object ReporterApp extends App {
   }
 
   private def reportFromSparklensDump(file: String): Unit = {
+    EmailReportHelper.generateReport(file, conf)
     val fs = FileSystem.get(new URI(file), HDFSConfigHelper.getHadoopConf(None))
 
     val path = new Path(file)

--- a/src/main/scala/com/qubole/sparklens/app/ReporterApp.scala
+++ b/src/main/scala/com/qubole/sparklens/app/ReporterApp.scala
@@ -71,7 +71,6 @@ object ReporterApp extends App {
   }
 
   private def reportFromSparklensDump(file: String): Unit = {
-    EmailReportHelper.generateReport(file, conf)
     val fs = FileSystem.get(new URI(file), HDFSConfigHelper.getHadoopConf(None))
 
     val path = new Path(file)
@@ -79,6 +78,7 @@ object ReporterApp extends App {
     fs.open(path).readFully(byteArray)
 
     val json = (byteArray.map(_.toChar)).mkString
+    EmailReportHelper.generateReport(json, conf)
     startAnalysersFromString(json)
 
   }

--- a/src/main/scala/com/qubole/sparklens/helper/EmailReportHelper.scala
+++ b/src/main/scala/com/qubole/sparklens/helper/EmailReportHelper.scala
@@ -1,7 +1,7 @@
 package com.qubole.sparklens.helper
 
-import java.io.File
-import java.io.FileWriter
+import java.io.{File, FileWriter}
+import java.nio.file.{Files, Paths}
 
 import com.mashape.unirest.http.Unirest
 import org.apache.spark.SparkConf
@@ -25,7 +25,10 @@ object EmailReportHelper {
         }
         val tempFileLocation = getTempFileLocation()
         try {
+          val file = new File(tempFileLocation)
+          file.getParentFile.mkdirs()
           val fileWriter = new FileWriter(tempFileLocation)
+
           fileWriter.write(appContextString)
           fileWriter.close()
           val response = Unirest.post("http://sparklens.qubole.com/generate_report/request_generate_report")
@@ -35,10 +38,10 @@ object EmailReportHelper {
           println(response.getBody)
         } catch {
           case e: Exception =>
-            println(e.getMessage)
+            println(s"Error while trying to generate email report: ${e.getMessage} \n " +
+              s"Try to use sparklens.qubole.com to generate the report manually" )
         } finally {
-          val file = new File(tempFileLocation)
-          file.deleteOnExit()
+          Files.deleteIfExists(Paths.get(tempFileLocation))
         }
       case _ =>
     }

--- a/src/main/scala/com/qubole/sparklens/helper/EmailReportHelper.scala
+++ b/src/main/scala/com/qubole/sparklens/helper/EmailReportHelper.scala
@@ -1,23 +1,37 @@
 package com.qubole.sparklens.helper
 
 import java.io.File
+import java.io.FileWriter
 
 import com.mashape.unirest.http.Unirest
 import org.apache.spark.SparkConf
 
 object EmailReportHelper {
 
-  def generateReport(sparklensJsonFile: String, conf: SparkConf): Unit = {
-    Option(conf.get("spark.sparklens.report.email")) match {
+  def getTempFileLocation(): String = {
+    val random = new scala.util.Random(31)
+    s"/tmp/sparklens/${random.nextInt.toString}.json"
+  }
+
+  def generateReport(appContextString: String, conf: SparkConf): Unit = {
+    Option(conf.get("spark.sparklens.report.email", null)) match {
       case Some(email) =>
+        val tempFileLocation = getTempFileLocation()
         try {
+          val fileWriter = new FileWriter(tempFileLocation)
+          fileWriter.write(appContextString)
+          fileWriter.close()
           val response = Unirest.post("http://sparklens.qubole.com/generate_report/request_generate_report")
-            .field("file-2[]", new File(sparklensJsonFile))
+            .field("file-2[]", new File(tempFileLocation))
             .field("email", email)
             .asJson()
+          println(response.getBody)
         } catch {
           case e: Exception =>
             println(e.getMessage)
+        } finally {
+          val file = new File(tempFileLocation)
+          file.deleteOnExit()
         }
       case _ =>
     }

--- a/src/main/scala/com/qubole/sparklens/helper/EmailReportHelper.scala
+++ b/src/main/scala/com/qubole/sparklens/helper/EmailReportHelper.scala
@@ -1,0 +1,25 @@
+package com.qubole.sparklens.helper
+
+import java.io.File
+
+import com.mashape.unirest.http.Unirest
+import org.apache.spark.SparkConf
+
+object EmailReportHelper {
+
+  def generateReport(sparklensJsonFile: String, conf: SparkConf): Unit = {
+    Option(conf.get("spark.sparklens.report.email")) match {
+      case Some(email) =>
+        try {
+          val response = Unirest.post("http://sparklens.qubole.com/generate_report/request_generate_report")
+            .field("file-2[]", new File(sparklensJsonFile))
+            .field("email", email)
+            .asJson()
+        } catch {
+          case e: Exception =>
+            println(e.getMessage)
+        }
+      case _ =>
+    }
+  }
+}

--- a/src/main/scala/com/qubole/sparklens/helper/EmailReportHelper.scala
+++ b/src/main/scala/com/qubole/sparklens/helper/EmailReportHelper.scala
@@ -1,16 +1,15 @@
 package com.qubole.sparklens.helper
 
-import java.io.{File, FileWriter}
+import java.io.FileWriter
 import java.nio.file.{Files, Paths}
 
-import com.mashape.unirest.http.Unirest
 import org.apache.spark.SparkConf
 
 object EmailReportHelper {
 
   def getTempFileLocation(): String = {
     val random = new scala.util.Random(31)
-    s"/tmp/sparklens/${random.nextInt.toString}.json"
+    s"/tmp/${random.nextInt.toString}.json"
   }
 
   def isValid(email: String): Boolean =
@@ -25,17 +24,12 @@ object EmailReportHelper {
         }
         val tempFileLocation = getTempFileLocation()
         try {
-          val file = new File(tempFileLocation)
-          file.getParentFile.mkdirs()
           val fileWriter = new FileWriter(tempFileLocation)
 
           fileWriter.write(appContextString)
           fileWriter.close()
-          val response = Unirest.post("http://sparklens.qubole.com/generate_report/request_generate_report")
-            .field("file-2[]", new File(tempFileLocation))
-            .field("email", email)
-            .asJson()
-          println(response.getBody)
+          val response = HttpRequestHandler.requestReport(tempFileLocation, email)
+          println(response.getEntity)
         } catch {
           case e: Exception =>
             println(s"Error while trying to generate email report: ${e.getMessage} \n " +

--- a/src/main/scala/com/qubole/sparklens/helper/EmailReportHelper.scala
+++ b/src/main/scala/com/qubole/sparklens/helper/EmailReportHelper.scala
@@ -13,9 +13,16 @@ object EmailReportHelper {
     s"/tmp/sparklens/${random.nextInt.toString}.json"
   }
 
+  def isValid(email: String): Boolean =
+    """(\w+)@([\w\.]+)""".r.unapplySeq(email).isDefined
+
   def generateReport(appContextString: String, conf: SparkConf): Unit = {
     Option(conf.get("spark.sparklens.report.email", null)) match {
       case Some(email) =>
+        if (!isValid(email)) {
+          println(s"Email $email is not valid. Please provide a valid email.")
+          return
+        }
         val tempFileLocation = getTempFileLocation()
         try {
           val fileWriter = new FileWriter(tempFileLocation)

--- a/src/main/scala/com/qubole/sparklens/helper/HttpRequestHandler.scala
+++ b/src/main/scala/com/qubole/sparklens/helper/HttpRequestHandler.scala
@@ -1,0 +1,29 @@
+package com.qubole.sparklens.helper
+
+import org.apache.http.client.methods.RequestBuilder
+import org.apache.http.entity.ContentType
+import org.apache.http.entity.mime.HttpMultipartMode
+import org.apache.http.entity.mime.MultipartEntityBuilder
+import org.apache.http.impl.client.HttpClients
+import java.io.File
+
+import org.apache.http.HttpResponse
+
+object HttpRequestHandler {
+
+  def requestReport(fileName: String, email: String): HttpResponse = {
+    val httpclient = HttpClients.createDefault()
+    val file = new File(fileName)
+    val builder = MultipartEntityBuilder.create()
+      .setMode(HttpMultipartMode.BROWSER_COMPATIBLE)
+      .addBinaryBody("file-2", file, ContentType.DEFAULT_BINARY, file.getName())
+      .addTextBody("email", email)
+    val postData = builder.build()
+    val request = RequestBuilder
+      .post("http://sparklens.qubole.com/generate_report/request_generate_report")
+      .setEntity(postData)
+      .build()
+    val response = httpclient.execute(request)
+    response
+  }
+}


### PR DESCRIPTION
With this change users can now pass the extra conf `spark.sparklens.report.email` to get a report similar to http://sparklens.qubole.com/report_view/1b3868a49388e7ab6a16 in the specified email.

This will work for online/offline (with sparklens JSON or event history file). 

Still a WIP. Few to do -
1. Add a threshold on the size of the sparkles JSON file to not overwhelm the service.
2. Add functionality to render a report with the sparklens.json.out which will be useful in case of online reporting to reduce the possible burden on the service.

cc @iamrohit 