### PR TITLE
Added JSON support

### DIFF
--- a/src/main/scala/com/qubole/sparklens/QuboleNotebookListener.scala
+++ b/src/main/scala/com/qubole/sparklens/QuboleNotebookListener.scala
@@ -76,6 +76,30 @@ Use spark.sql(""" Your Query """) scala or python snippet to profile it
 class QuboleNotebookListener(sparkConf: SparkConf) extends QuboleJobListener(sparkConf: SparkConf) {
 
   private lazy val defaultExecutorCores = sparkConf.getInt("spark.executor.cores", 2)
+
+  def getStats_json(fromTime: Long, toTime: Long) : String = {
+
+    val list = new ListBuffer[AppAnalyzer]
+    list += new StageSkewAnalyzer
+    list += new ExecutorWallclockAnalyzer
+    list += new EfficiencyStatisticsAnalyzer
+
+    val appContext = new AppContext(appInfo,
+      appMetrics,
+      hostMap,
+      executorMap,
+      jobMap,
+      jobSQLExecIDMap,
+      stageMap,
+      stageIDToJobID)
+
+    val appContextFiltered = appContext.filterByStartAndEndTime(fromTime, toTime)
+    appContextFiltered.appInfo.startTime = fromTime
+    appContextFiltered.appInfo.endTime = toTime
+
+    appContext.toString
+  }
+
   /**
     * No need to print statistics at the end of the Job
     * @param applicationEnd


### PR DESCRIPTION
Added JSON support by method QNL.getStats_json.
Usage shown below


******** SET-UP **************
QNL = sc._jvm.com.qubole.sparklens.QuboleNotebookListener.registerAndGet(sc._jsc.sc())
import time
if (QNL.estimateSize() > QNL.getMaxDataSize()):
  QNL.purgeJobsAndStages()
startTime = int(round(time.time() * 1000))
******** SET-UP **************

SPARK-CODE

******** END **************
endTime = int(round(time.time() * 1000))
time.sleep(QNL.getWaiTimeInSeconds())
stats_json = QNL.getStats_json(startTime, endTime)
print(stats_json)
# Save to FIle, Print will truncate the data
******** END **************