### PR TITLE
Add the support for the sparklens in spark-3.0.0 and later version of spark with scala-2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,16 +92,31 @@ Note: Apart from the console based report, you can also get an UI based report s
  `--conf spark.sparklens.report.email=<email>` along with other relevant confs mentioned below.
  This functionality is available in Sparklens 0.3.2 and above.  
 
-Use the following arguments to `spark-submit` or `spark-shell`:
+Use the following arguments to `spark-submit` or `spark-shell` for spark-3.0.0 and latest version of spark:
+```
+--packages qubole:sparklens:0.4.0-s_2.12
+--conf spark.extraListeners=com.qubole.sparklens.QuboleJobListener
+```
+
+Use the following arguments to `spark-submit` or `spark-shell` for spark-2.4.x and lower version of spark:
 ```
 --packages qubole:sparklens:0.3.2-s_2.11
 --conf spark.extraListeners=com.qubole.sparklens.QuboleJobListener
 ```
 
+
 #### 2. Run from Sparklens offline data ####
 
 You can choose not to run sparklens inside the app, but at a later time. Run your app as above 
-with additional configuration parameters:
+with additional configuration parameters
+For spark-3.0.0 and latest version of spark:
+```
+--packages qubole:sparklens:0.4.0-s_2.12
+--conf spark.extraListeners=com.qubole.sparklens.QuboleJobListener
+--conf spark.sparklens.reporting.disabled=true
+```
+
+For spark-2.4.x and lower version of spark:
 ```
 --packages qubole:sparklens:0.3.2-s_2.11
 --conf spark.extraListeners=com.qubole.sparklens.QuboleJobListener
@@ -111,7 +126,7 @@ with additional configuration parameters:
 This will not run reporting, but instead create a Sparklens JSON file for the application which is 
 stored in the **spark.sparklens.data.dir** directory (by default, **/tmp/sparklens/**). Note that this will be stored on HDFS by default. To save this file to s3, please set **spark.sparklens.data.dir** to s3 path. This data file can now be used to run Sparklens reporting independently, using `spark-submit` command as follows:
 
-`./bin/spark-submit --packages qubole:sparklens:0.3.2-s_2.11 --class com.qubole.sparklens.app.ReporterApp qubole-dummy-arg <filename>`
+`./bin/spark-submit --packages qubole:sparklens:0.4.0-s_2.12 --class com.qubole.sparklens.app.ReporterApp qubole-dummy-arg <filename>`
 
 `<filename>` should be replaced by the full path of sparklens json file. If the file is on s3 use the full s3 path. For files on local file system, use file:// prefix with the local file location. HDFS is supported as well. 
 
@@ -124,11 +139,11 @@ running via `sparklens-json-file` above) with another option specifying that is 
 event history file. This file can be in any of the formats the event history files supports, i.e. **text, snappy, lz4 
 or lzf**. Note the extra `source=history` parameter in this example:
 
-`./bin/spark-submit --packages qubole:sparklens:0.3.2-s_2.11 --class com.qubole.sparklens.app.ReporterApp qubole-dummy-arg <filename> source=history`
+`./bin/spark-submit --packages qubole:sparklens:0.4.0-s_2.12 --class com.qubole.sparklens.app.ReporterApp qubole-dummy-arg <filename> source=history`
 
 It is also possible to convert an event history file to a Sparklens json file using the following command:
 
-`./bin/spark-submit --packages qubole:sparklens:0.3.2-s_2.11 --class com.qubole.sparklens.app.EventHistoryToSparklensJson qubole-dummy-arg <srcDir> <targetDir>`
+`./bin/spark-submit --packages qubole:sparklens:0.4.0-s_2.12 --class com.qubole.sparklens.app.EventHistoryToSparklensJson qubole-dummy-arg <srcDir> <targetDir>`
 
 EventHistoryToSparklensJson is designed to work on local file system only. Please make sure that the source and target directories are on local file system.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,13 @@
 name := "sparklens"
 organization := "com.qubole"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.10"
 
-crossScalaVersions := Seq("2.10.6", "2.11.8")
+crossScalaVersions := Seq("2.10.6", "2.11.12", "2.12.10")
 
 spName := "qubole/sparklens"
 
-sparkVersion := "2.0.0"
+sparkVersion := "3.0.1"
 
 spAppendScalaVersion := true
 

--- a/src/main/scala/com/qubole/sparklens/QuboleJobListener.scala
+++ b/src/main/scala/com/qubole/sparklens/QuboleJobListener.scala
@@ -257,7 +257,8 @@ class QuboleJobListener(sparkConf: SparkConf)  extends SparkListener {
     if (stageCompleted.stageInfo.failureReason.isDefined) {
       //stage failed
       val si = stageCompleted.stageInfo
-      failedStages += s""" Stage ${si.stageId} attempt ${si.attemptId} in job ${stageIDToJobID(si.stageId)} failed.
+      // attempt-id is deprecated and attemptNumber is used to get attempt-id from spark-3.0.0
+      failedStages += s""" Stage ${si.stageId} attempt ${si.attemptNumber} in job ${stageIDToJobID(si.stageId)} failed.
                       Stage tasks: ${si.numTasks}
                       """
       stageTimeSpan.finalUpdate()

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.2"
+version in ThisBuild := "0.4.0"


### PR DESCRIPTION
In spark 3.0.0 there are lots of changes done by the community , so creating this improvement PR to make the sparklens work with spark 3.0.0 / new version of spark and scala-2.12.

I have made code change  and also tested the same .please find the output

./bin/spark-shell --jars file:///tmp//src/opensrc/sparklens/target/scala-2.12/sparklens_2.12-0.4.0.jar --conf spark.extraListeners=com.qubole.sparklens.QuboleJobListener --conf  spark.eventLog.enabled=true


```Saving sparkLens data to /tmp/sparklens//local-1616169770100.sparklens.json

Printing application meterics. These metrics are collected at task-level granularity and aggregated across the app (all tasks, stages, and jobs).

 AggregateMetrics (Application Metrics) total measurements 20 
                NAME                        SUM                MIN           MAX                MEAN         
 diskBytesSpilled                            0.0 KB         0.0 KB         0.0 KB              0.0 KB
 executorRuntime                           344.0 ms         3.0 ms        30.0 ms             17.0 ms
 inputBytesRead                              0.0 KB         0.0 KB         0.0 KB              0.0 KB
 jvmGCTime                                   1.3 ss         0.0 ms       130.0 ms             65.0 ms
 memoryBytesSpilled                          0.0 KB         0.0 KB         0.0 KB              0.0 KB
 outputBytesWritten                          0.0 KB         0.0 KB         0.0 KB              0.0 KB
 peakExecutionMemory                         0.0 KB         0.0 KB         0.0 KB              0.0 KB
 resultSize                                 17.5 KB         0.9 KB         0.9 KB              0.9 KB
 shuffleReadBytesRead                        0.0 KB         0.0 KB         0.0 KB              0.0 KB
 shuffleReadFetchWaitTime                    0.0 ms         0.0 ms         0.0 ms              0.0 ms
 shuffleReadLocalBlocks                           0              0              0                   0
 shuffleReadRecordsRead                           0              0              0                   0
 shuffleReadRemoteBlocks                          0              0              0                   0
 shuffleWriteBytesWritten                    0.0 KB         0.0 KB         0.0 KB              0.0 KB
 shuffleWriteRecordsWritten                       0              0              0                   0
 shuffleWriteTime                            0.0 ms         0.0 ms         0.0 ms              0.0 ms
 taskDuration                                4.3 ss        10.0 ms       441.0 ms            215.0 ms




Total Hosts 1, and the maximum concurrent hosts = 1


Host 192.168.1.19 startTime 09:32:50:262 executors count 1
Done printing host timeline
======================



Printing executors timeline....

Total Executors 1, and maximum concurrent executors = 1
At 09:32 executors added 1 & removed  0 currently available 1

Done printing executors timeline...
============================



Printing Application timeline 

09:32:49:492 app started 
09:32:57:059 JOB 0 started : duration 00m 00s 
[      0                                      |||||||||||||||||||||||||||||||||||||||||| ]
09:32:57:448      Stage 0 started : duration 00m 00s 
09:32:57:889      Stage 0 ended : maxTaskTime 30 taskCount 10
09:32:57:899 JOB 0 ended 
09:33:01:125 JOB 1 started : duration 00m 00s 
[      1        |||||||||||||||||                                                        ]
09:33:01:132      Stage 1 started : duration 00m 00s 
09:33:01:149      Stage 1 ended : maxTaskTime 6 taskCount 10
09:33:01:150 JOB 1 ended 
09:33:03:044 app ended 



Checking for job overlap...

 
 JobGroup 1  SQLExecID (-1)
 Number of Jobs 1  JobIDs(0)
 Timing [09:32:57:059 - 09:32:57:899]
 Duration  00m 00s
 
 JOB 0 Start 09:32:57:059  End 09:32:57:899
 
 
 JobGroup 2  SQLExecID (-1)
 Number of Jobs 1  JobIDs(1)
 Timing [09:33:01:125 - 09:33:01:150]
 Duration  00m 00s
 
 JOB 1 Start 09:33:01:125  End 09:33:01:150
 

No overlapping jobgroups found. Good




 Time spent in Driver vs Executors
 Driver WallClock Time    00m 12s   93.62%
 Executor WallClock Time  00m 00s   6.38%
 Total WallClock Time     00m 13s
      


Minimum possible time for the app based on the critical path (with infinite resources)   00m 12s
Minimum possible time for the app with same executors, perfect parallelism and zero skew 00m 12s
If we were to run this app with single executor and single core                          00h 00m

       
 Total cores available to the app 16

 OneCoreComputeHours: Measure of total compute power available from cluster. One core in the executor, running
                      for one hour, counts as one OneCoreComputeHour. Executors with 4 cores, will have 4 times
                      the OneCoreComputeHours compared to one with just one core. Similarly, one core executor
                      running for 4 hours will OnCoreComputeHours equal to 4 core executor running for 1 hour.

 Driver Utilization (Cluster idle because of driver)

 Total OneCoreComputeHours available                             00h 03m
 Total OneCoreComputeHours available (AutoScale Aware)           00h 03m
 OneCoreComputeHours wasted by driver                            00h 03m

 AutoScale Aware: Most of the calculations by this tool will assume that all executors are available throughout
                  the runtime of the application. The number above is printed to show possible caution to be
                  taken in interpreting the efficiency metrics.

 Cluster Utilization (Executors idle because of lack of tasks or skew)

 Executor OneCoreComputeHours available                  00h 00m
 Executor OneCoreComputeHours used                       00h 00m        2.49%
 OneCoreComputeHours wasted                              00h 00m        97.51%

 App Level Wastage Metrics (Driver + Executor)

 OneCoreComputeHours wasted Driver               93.62%
 OneCoreComputeHours wasted Executor             6.22%
 OneCoreComputeHours wasted Total                99.84%

       


 App completion time and cluster utilization estimates with different executor counts

 Real App Duration 00m 13s
 Model Estimation  00m 12s
 Model Error       6%

 NOTE: 1) Model error could be large when auto-scaling is enabled.
       2) Model doesn't handles multiple jobs run via thread-pool. For better insights into
          application scalability, please try such jobs one by one without thread-pool.

       
 Executor count     1  (100%) estimated time 00m 12s and estimated cluster utilization 0.17%
 Executor count     1  (110%) estimated time 00m 12s and estimated cluster utilization 0.17%
 Executor count     1  (120%) estimated time 00m 12s and estimated cluster utilization 0.17%
 Executor count     1  (150%) estimated time 00m 12s and estimated cluster utilization 0.17%
 Executor count     2  (200%) estimated time 00m 12s and estimated cluster utilization 0.08%
 Executor count     3  (300%) estimated time 00m 12s and estimated cluster utilization 0.06%
 Executor count     4  (400%) estimated time 00m 12s and estimated cluster utilization 0.04%
 Executor count     5  (500%) estimated time 00m 12s and estimated cluster utilization 0.03%



Total tasks in all stages 20
Per Stage  Utilization
Stage-ID   Wall    Task      Task     IO%    Input     Output    ----Shuffle-----    -WallClockTime-    --OneCoreComputeHours---   MaxTaskMem
          Clock%  Runtime%   Count                               Input  |  Output    Measured | Ideal   Available| Used%|Wasted%                                  
       0   96.00   84.30        10    NaN    0.0 KB    0.0 KB    0.0 KB    0.0 KB    00m 00s   00m 00s    00h 00m    4.1   95.9    0.0 KB 
       1    3.00   15.70        10    NaN    0.0 KB    0.0 KB    0.0 KB    0.0 KB    00m 00s   00m 00s    00h 00m   19.9   80.1    0.0 KB 
Max memory which an executor could have taken =   0.0 KB


 Stage-ID WallClock  OneCore       Task   PRatio    -----Task------   OIRatio  |* ShuffleWrite% ReadFetch%   GC%  *|
          Stage%     ComputeHours  Count            Skew   StageSkew                                                
      0   96.29         00h 00m      10    0.63     1.03     0.07     0.00     |*   0.00           0.00   448.28  *|
      1    3.71         00h 00m      10    0.63     1.00     0.35     0.00     |*   0.00           0.00     0.00  *|

PRatio:        Number of tasks in stage divided by number of cores. Represents degree of
               parallelism in the stage
TaskSkew:      Duration of largest task in stage divided by duration of median task.
               Represents degree of skew in the stage
TaskStageSkew: Duration of largest task in stage divided by total duration of the stage.
               Represents the impact of the largest task on stage time.
OIRatio:       Output to input ration. Total output of the stage (results + shuffle write)
               divided by total input (input data + shuffle read)

These metrics below represent distribution of time within the stage

ShuffleWrite:  Amount of time spent in shuffle writes across all tasks in the given
               stage as a percentage
ReadFetch:     Amount of time spent in shuffle read across all tasks in the given
               stage as a percentage
GC:            Amount of time spent in GC across all tasks in the given stage as a
               percentage

If the stage contributes large percentage to overall application time, we could look into
these metrics to check which part (Shuffle write, read fetch or GC is responsible)```
