### PR TITLE
plugins.sbt updated with new resolver

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.12.0")
 
-resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
+resolvers += "Spark Package Main Repo" at "https://repos.spark-packages.org"
 
 addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.4")
 


### PR DESCRIPTION
replaced  https://dl.bintray.com/spark-packages/maven  with https://repos.spark-packages.org to resolve ResolverException issue, as dl.bintray is sunset and forbidden.