### PR TITLE
Fix Outdated Configuration

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,5 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.12.0")
 
-resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
+resolvers += "spark-packages" at "https://repos.spark-packages.org/"
 
 addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.4")
-
-
-
-


### PR DESCRIPTION
The previous configuration causes an error when compiling the project:
```
[error] (*:update) sbt.ResolveException: unresolved dependency: org/spark-packages#sbt-spark-package;0.2.4: not found
```